### PR TITLE
Output timestamp as RFC3339

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ A really simple Python script to dump a Current Cost CC128 energy meter connecte
 Produces a never ending CSV file that looks like:
 
 ```
-1477815247,218
-1477815259,212
-1477815265,211
-1477815271,215
-1477815277,211
+2017-04-28T16:32:31Z,379
+2017-04-28T16:32:37Z,371
+2017-04-28T16:32:43Z,369
+2017-04-28T16:32:49Z,381
+2017-04-28T16:32:55Z,377
 ```

--- a/currentcost.py
+++ b/currentcost.py
@@ -1,10 +1,28 @@
 #!/usr/bin/env python
+
+import datetime
 import serial
 from xml.etree.cElementTree import fromstring
 import time
 import csv
 import signal
 import sys
+
+
+class UTC(datetime.tzinfo):
+    def utcoffset(self, dt):
+        return datetime.timedelta(0)
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return datetime.timedelta(0)
+
+
+def utc_now_string():
+    return datetime.datetime.now(UTC()).strftime('%Y-%m-%dT%H:%M:%SZ')
+
 
 serial = serial.Serial('/dev/ttyUSB0', 57600)
 
@@ -33,8 +51,7 @@ with open('/srv/currentcost/currentcost.csv', 'a') as csvfile:
 
             watts = int(xml.find('ch1').find('watts').text)
 
-            now = time.time()
-            timestamp = int(now)
+            timestamp = utc_now_string()
 
             row = [timestamp, watts]
             writer.writerow(row)


### PR DESCRIPTION
Previously when I was handling this data from @tomtaylor's house it was tricky to know how to handle daylight savings time.

In this scheme the time will always be output as UTC, and use the `Z` suffix to show that. (Right now, it's 17:41 in british summer time and the times are coming out at 16:41, UTC)